### PR TITLE
Debian packaging touchups

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,15 +2,29 @@ Source: com.github.matthiasjg.trimirjournal
 Section: x11
 Priority: extra
 Maintainer: Matthias Joachim Geisler <matthiasjg@openwebcraft.com>
-Build-Depends: debhelper (>= 10.5.1),
+Build-Depends: debhelper (>= 11),
                gettext,
                libgtk-3-dev (>= 3.10),
+               libxml2-dev,
+               libgda-5.0-dev,
+               libglib2.0-dev,
+               libgranite-dev (>= 6.0.0),
+               libhandy-1-dev,
+               libwebkit2gtk-4.0-dev,
+               libjson-glib-dev,
+               libgtksourceview-4-dev,
+               libarchive-dev,
                meson,
-               valac (>= 0.28.0)
+               valac (>= 0.28.0),
 Standards-Version: 4.1.1
 
 Package: com.github.matthiasjg.trimirjournal
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}
-Description: Trimir Journal
- This is a Journaling App written in Vala using Meson build system.
+Description: Your personal activity Tricorder
+ Journaling app designed and built for personal text journaling and activity 
+ tracking.
+ .
+ Write a diary, log your activities, keep track of your metrics.
+ .
+ Search, filter and evaluate your journal — your life.

--- a/debian/rules
+++ b/debian/rules
@@ -1,10 +1,4 @@
 #!/usr/bin/make -f
-# -*- makefile -*-
-# Sample debian/rules that uses debhelper.
-# This file was originally written by Joey Hess and Craig Small.
-# As a special exception, when this file is copied by dh-make into a
-# dh-make output file, you may use that output file without restriction.
-# This special exception was added by Craig Small in version 0.37 of dh-make.
 
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1

--- a/debian/rules
+++ b/debian/rules
@@ -10,5 +10,4 @@
 #export DH_VERBOSE=1
 
 %:
-	dh $@ 
-
+	dh $@ --buildsystem=meson


### PR DESCRIPTION
not perfect yet, but better, and allows building on Debian 11 as long as libgranite6 and livechart are installed (which are not available in Debian 11)

building still fails unless tests are excluded, haven't been able to get time to look at it more, but the built amd64, i386, and armhf packages work based on limited testing I've done so far